### PR TITLE
Update TFF RFC logging to TFF 0.13.1

### DIFF
--- a/20190924-tensorflow-federated/custom_executor_stacks.py
+++ b/20190924-tensorflow-federated/custom_executor_stacks.py
@@ -1,9 +1,9 @@
 import tensorflow_federated as tff
 
 from tensorflow_federated.python.core import framework
-from tensorflow_federated.python.core.impl.executors.eager_executor import EagerExecutor
-from tensorflow_federated.python.core.impl.executors.federated_executor import FederatedExecutor
-from tensorflow_federated.python.core.impl.executors.lambda_executor import LambdaExecutor
+from tensorflow_federated.python.core.impl.executors.eager_tf_executor import EagerTFExecutor
+from tensorflow_federated.python.core.impl.executors.federating_executor import FederatingExecutor
+from tensorflow_federated.python.core.impl.executors.reference_resolving_executor import ReferenceResolvingExecutor
 
 from secure_federated_executor import SecureFederatedExecutor
 
@@ -15,21 +15,21 @@ def builtin_executor_stack(num_clients):
 
     def _complete_stack(ex):
       return \
-          LambdaExecutor(
+          ReferenceResolvingExecutor(
           # CachingExecutor(
           # ConcurrentExecutor(
           ex
       )
 
     def _create_bottom_stack():
-      return _complete_stack(EagerExecutor())
+      return _complete_stack(EagerTFExecutor())
 
     executor_dict = {
         tff.CLIENTS: [_create_bottom_stack() for _ in range(num_clients)],
         tff.SERVER: _create_bottom_stack(),
         None: _create_bottom_stack(),
     }
-    return _complete_stack(FederatedExecutor(executor_dict))
+    return _complete_stack(FederatingExecutor(executor_dict))
 
   return executor_fn
 
@@ -41,25 +41,25 @@ def secure_executor_stack(num_clients):
 
     def _complete_stack(ex):
       return \
-          LambdaExecutor(
+          ReferenceResolvingExecutor(
           # CachingExecutor(
           # ConcurrentExecutor(
           ex
       )
 
     def _create_bottom_stack():
-      return _complete_stack(EagerExecutor())
+      return _complete_stack(EagerTFExecutor())
 
     executor_dict = {
         tff.CLIENTS: [_create_bottom_stack() for _ in range(num_clients)],
         tff.SERVER: _create_bottom_stack(),
         None: _create_bottom_stack(),
     }
-    return _complete_stack(SecureFederatedExecutor(FederatedExecutor(executor_dict)))
+    return _complete_stack(SecureFederatedExecutor(FederatingExecutor(executor_dict)))
 
   return executor_fn
 
 
 def framework_executor_stack(num_clients):
-  return framework.create_local_executor(num_clients=num_clients)
+  return framework.local_executor_factory(num_clients=num_clients)
  

--- a/20190924-tensorflow-federated/logging_helpers.py
+++ b/20190924-tensorflow-federated/logging_helpers.py
@@ -288,4 +288,13 @@ register_formatting_strategy(tff.proto.v0.computation_pb2.Computation,
     lambda x: "<ComputationPb {} @{} : {}>".format(x.WhichOneof('computation'), id(x), x.type.WhichOneof('type')))
 
 register_formatting_strategy(tff.python.common_libs.anonymous_tuple.AnonymousTuple,
-    lambda x: "<anonymous tuple @{}>".format(id(x)))
+    lambda x: "<AnonymousTuple @{} : {}>".format(id(x), format_anon_tuple(x)))
+
+def format_anon_tuple(tup):
+  names = tup._name_array
+  values = tup._element_array
+  fmt_strs = []
+  for n, v in zip(names, values):
+    fmt_strs.append("{}: {}".format(n, format_object(v)))
+
+  return "({})".format(", ".join(fmt_strs))

--- a/20190924-tensorflow-federated/simple.py
+++ b/20190924-tensorflow-federated/simple.py
@@ -32,4 +32,5 @@ logging_helpers.set_default_executor(executor_fn)
 # print(foo(5.0))
 
 res = add_half_on_clients([1.5, 2.5, 3.5])
+# res = foo(5.)
 print(res)


### PR DESCRIPTION
- Updates code to TFF 0.13.1
- Improves logging_helpers.py formatting

`python simple.py > dump.py` is a good way to experiment with the logging utils.